### PR TITLE
PM-1726 Log invalid submissions

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -67,6 +67,14 @@ func main() {
 		if err != nil {
 			log.Fatalf("Error updating submissions: %v", err)
 		}
+
+		log.Info("Invalid submissions:")
+		for _, sub := range verifiedSubmissions {
+			if sub.ValidationError != "" || !sub.Verified {
+				log.Infof("[INVALID] Submitter: %s, Block hash: %s, Submitted at: %s, Validation error: %s, Verified: %v",
+					sub.Submitter, sub.BlockHash, sub.SubmittedAt, sub.ValidationError, sub.Verified)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Each stateless_verifier job will additionally print the list of submissions that don't pass the validation:
```
{"level":"info","ts":"2024-06-06T13:09:52.290+0200","logger":"Submission Updater","caller":"src/main.go:74","msg":"[INVALID] Submitter: B62qnZEWRGp4eRCzzpVRmEqA8wTPjKmm3NSzGNzxDww9yHHo9vnRdmc, Block hash: YKZsMkG2FHrqR3mPBv3wYsGJe5mMZHcDf6oQsC1Tu6G6Av5gcm, Submitted at: 2024-06-04 10:32:03 +0000 UTC, Validation error: Fail to decode block, Verified: true"}
{"level":"info","ts":"2024-06-06T13:09:52.290+0200","logger":"Submission Updater","caller":"src/main.go:74","msg":"[INVALID] Submitter: B62qnZEWRGp4eRCzzpVRmEqA8wTPjKmm3NSzGNzxDww9yHHo9vnRdmc, Block hash: YKZsMkG2FHrqR3mPBv3wYsGJe5mMZHcDf6oQsC1Tu6G6Av5gcm, Submitted at: 2024-06-04 21:13:25 +0000 UTC, Validation error: Fail to decode block, Verified: true"}
...
```
It can be easily filtered out in Grafana/Loki by `INVALID` keyword.