### PR TITLE
PM-1727 Add option to provide GENESIS_LEDGER_FILE into stateless_verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ make
   - `DELEGATION_VERIFY_BIN_PATH` - path to [Stateless verifier tool](https://github.com/MinaProtocol/mina/tree/develop/src/app/delegation_verify) binary.
   - `NO_CHECKS` - if set to `1`, stateless verifier tool will run with `--no-checks` flag
   - `SUBMISSION_STORAGE` - Storage where submissions are kept. Valid options: `POSTGRES` or `CASSANDRA`. Default: `POSTGRES`.
+  - `GENESIS_LEDGER_FILE` - file path to genesis ledger file. This is input for stateless_verifier `--config-file` option. In principle it is optional, if set, stateless_verifier will be run with `--config-file GENESIS_LEDGER_FILE` option.
 
 **2. AWS Keyspaces/Cassandra Configuration**:
 
@@ -69,7 +70,10 @@ $ ./result/bin/cassandra-updater "2024-03-04 09:38:54.0+0000" "2024-03-04 09:45:
 
 We can build docker image containing both `submission-updater` and [Stateless verifier tool](https://github.com/MinaProtocol/mina/tree/develop/src/app/delegation_verify). For that we need to feed build with `DUNE_PROFILE` and `MINA_BRANCH` env variables. `DUNE_PROFILE` is the profile in which the tool will be built (typically `devnet`). `MINA_BRANCH` indicates which branch of [Mina](https://github.com/MinaProtocol/mina) repository we want to build the tool from.
 
-The docker image already has `DELEGATION_VERIFY_BIN_PATH` and `SSL_CERTFILE` already set, so we only need to feed it with remaining config variables required for connecting to AWS Keyspaces / Cassandra.
+The docker image already has set: 
+ - `DELEGATION_VERIFY_BIN_PATH`
+ - `SSL_CERTFILE` 
+ - `GENESIS_LEDGER_FILE` with mainnet genesis_ledger file. In case different ledger file is required one can override it by passing GENESIS_LEDGER_FILE to the docker container via `-e GENESIS_LEDGER_FILE=/different/path/genesis.json`. 
 
 **Build**:
 

--- a/dockerfiles/Dockerfile-delegation-verify
+++ b/dockerfiles/Dockerfile-delegation-verify
@@ -10,11 +10,11 @@
 FROM gcr.io/o1labs-192920/mina-toolchain@sha256:c810338e2c3973f7c674d0607048725917ce2be23b949c4bc9760c01122f884b AS builder
 
 # Use --build-arg "DUNE_PROFILE=dev" to build a dev image or for CI
-ARG DUNE_PROFILE=devnet
+ARG DUNE_PROFILE=mainnet
 
 # branch to checkout on first clone (this will be the only availible branch in the container)
 # can also be a tagged release
-ARG MINA_BRANCH=delegation_verify_over_stdin_rc_base
+ARG MINA_BRANCH=berkeley
 
 # repo to checkout the branch from
 ARG MINA_REPO=https://github.com/MinaProtocol/mina
@@ -82,6 +82,7 @@ WORKDIR $GOPATH/src
 # Copy everything from the current directory to the PWD (Present Working Directory) inside the container
 COPY src src
 COPY database/cert/sf-class2-root.crt /root/.cassandra/sf-class2-root.crt
+COPY genesis_ledgers/mainnet.json /root/genesis_ledgers/mainnet.json
 
 # Download all the dependencies
 RUN cd src && go get -d -v ./...
@@ -91,6 +92,7 @@ RUN cd src && go install -v ./...
 
 ENV DELEGATION_VERIFY_BIN_PATH=/bin/delegation-verify
 ENV SSL_CERTFILE=/root/.cassandra/sf-class2-root.crt
+ENV GENESIS_LEDGER_FILE=/root/genesis_ledgers/mainnet.json
 
 # Run the executable
 ENTRYPOINT ["submission_updater"]

--- a/genesis_ledgers/mainnet.json
+++ b/genesis_ledgers/mainnet.json
@@ -1,0 +1,29 @@
+{
+  "genesis": {
+    "genesis_state_timestamp": "2024-06-05T00:00:00Z"
+  },
+  "proof": {
+    "fork": {
+      "state_hash": "3NLRTfY4kZyJtvaP4dFenDcxfoMfT3uEpkWS913KkeXLtziyVd15",
+      "blockchain_length": 359604,
+      "global_slot_since_genesis": 564480
+    }
+  },
+  "ledger": {
+    "add_genesis_winner": false,
+    "hash": "jwNw4qb6tnNhpQNxiMLem9WumxZTwmbSx3fYXW4FP3hZRkoQJSE",
+    "s3_data_hash": "1b3c34283e6880a9dfdb7d5dc351e1c063f5865a13012d81acc8d55601d2c8f3"
+  },
+  "epoch_data": {
+    "staking": {
+      "seed": "2vahsgRV5nDPmtgr2Xo2Uq2dkngfSgvg7d1TKqQbY3wUS2ZDxCC3",
+      "hash": "jxsAidvKvEQJMC7Z2wkLrFGzCqUxpFMRhAj4K5o49eiFLhKSyXL",
+      "s3_data_hash": "ab6bec51c8523c0d041fab66cb9ca12b03842d3d77b1b06254d7a9c8dc33cbfc"
+    },
+    "next": {
+      "seed": "2vbH4D8B76WMYPRFgeuVvdWVhv6tAFoCJtg83yuJT1dud3QVSiZn",
+      "hash": "jwgzfxD5rEnSP3k4UiZu2569FfhJ1SRUvabfTz21e4btwBHg3jq",
+      "s3_data_hash": "61323d7565130cfa4768c0333f32b2a8ea7fdfbf17065adfa48b4e9956619b44"
+    }
+  }
+}

--- a/src/app_config.go
+++ b/src/app_config.go
@@ -18,6 +18,7 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 	delegationVerifyBinPath := getEnvChecked("DELEGATION_VERIFY_BIN_PATH", log)
 	noChecks := boolEnvChecked("NO_CHECKS", log)
 	networkName := getEnvChecked("NETWORK_NAME", log)
+	genesisLedgerFile := os.Getenv("GENESIS_LEDGER_FILE")
 
 	// AWS configurations
 	bucketName := getEnvChecked("AWS_S3_BUCKET", log)
@@ -71,6 +72,7 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 	config.NetworkName = networkName
 	config.DelegationVerifyBinPath = delegationVerifyBinPath
 	config.NoChecks = noChecks
+	config.GenesisLedgerFile = genesisLedgerFile
 	config.SubmissionStorage = submissionStorage
 	config.CassandraConfig = &CassandraConfig{
 		Keyspace:             awsKeyspace,
@@ -181,6 +183,7 @@ type AppConfig struct {
 	NetworkName             string            `json:"network_name"`
 	DelegationVerifyBinPath string            `json:"delegation_verify_bin_path"`
 	NoChecks                bool              `json:"no_checks"`
+	GenesisLedgerFile       string            `json:"genesis_ledger_file"`
 	SubmissionStorage       string            `json:"submission_storage"`
 	AwsConfig               *AwsConfig        `json:"aws"`
 	CassandraConfig         *CassandraConfig  `json:"cassandra_config,omitempty"`

--- a/src/main.go
+++ b/src/main.go
@@ -68,7 +68,6 @@ func main() {
 			log.Fatalf("Error updating submissions: %v", err)
 		}
 
-		log.Info("Invalid submissions:")
 		for _, sub := range verifiedSubmissions {
 			if sub.ValidationError != "" || !sub.Verified {
 				log.Infof("[INVALID] Submitter: %s, Block hash: %s, Submitted at: %s, Validation error: %s, Verified: %v",


### PR DESCRIPTION
This is change adds option to set `GENESIS_LEDGER_FILE` when running submission_updater. When set it will launch stateless_verifier with `--config-file $GENESIS_LEDGER_FILE`.

Current mainnet genesis `mainnet.json` is bundled with docker for convenience, however it can be overriden by passing  GENESIS_LEDGER_FILE while running the docker.