### PR TITLE
PM-1736 nullify snark_work to keep the space usage low

### DIFF
--- a/src/postgres.go
+++ b/src/postgres.go
@@ -60,8 +60,9 @@ func (ctx *AppContext) updateSubmissionsPostgres(submissions []Submission) error
 	ctx.Log.Infof("Updating %d submissions", len(submissions))
 
 	for _, sub := range submissions {
+		// We nullify snark_work to keep the space usage low
 		query := `UPDATE submissions
-                  SET state_hash = $1, parent = $2, height = $3, slot = $4, validation_error = $5, verified = $6
+                  SET snark_work = NULL, state_hash = $1, parent = $2, height = $3, slot = $4, validation_error = $5, verified = $6
                   WHERE id = $7`
 		if _, err := ctx.PostgresSession.Exec(query,
 			sub.StateHash, sub.Parent, sub.Height, sub.Slot, sub.ValidationError, sub.Verified,


### PR DESCRIPTION
We nullify snark_work post validation to keep the space usage low.